### PR TITLE
connectionPostgres agora tem o metodo getConnection

### DIFF
--- a/src/main/java/br/com/proway/senior/cargosESalarios/connection/ConnectionPostgres.java
+++ b/src/main/java/br/com/proway/senior/cargosESalarios/connection/ConnectionPostgres.java
@@ -15,12 +15,35 @@ import java.sql.Statement;
  * @author Sarah Brito, sarah.brito@senior.com.br
  */
 public final class ConnectionPostgres implements IConectar {
-	
-	private static ConnectionPostgres instance;
 	private static String url = "jdbc:postgresql://localhost:5432/grupo2";
 	private static String usuario = "postgres";
 	private static String senha = "admin";
-	private static Connection conexao;
+	
+	private static ConnectionPostgres instance;
+	private static Connection conexao = null;
+	
+	/**
+	 * Ao construir o singleton ocorre a conexão com o banco de dados e
+	 * essa conexao fica armazenada na variavel statica 'conexao'
+	 */
+	public ConnectionPostgres() {
+		conexao = this.conectar();
+	}
+	
+	/**
+	 * Retorna o objeto de conexao com o banco de dados armazenado na variavel 
+	 * static conexao. 
+	 * 
+	 * @return conexao
+	 */
+	public Connection getConnection() {
+		if (conexao == null) {
+			conexao = this.conectar();
+			System.out.println("Conexão Singleton estava nula mas foi estabelecida!");
+		}
+		System.out.println("Retornando Conexão Singleton...");
+		return conexao;
+	}
 	
 	/**
 	 * Mï¿½todo Conectar
@@ -41,6 +64,14 @@ public final class ConnectionPostgres implements IConectar {
 		return conexao;
 	}
 
+	/**
+	 * Retorna a instancia do Singleton. 
+	 * 
+	 * Essa função deve ser a unica forma de obter a referencia do Singleton para
+	 * uso.
+	 * 
+	 * @return
+	 */
 	public static ConnectionPostgres getInstance() {
 		if (instance == null) {
 			instance = new ConnectionPostgres();

--- a/src/main/java/br/com/proway/senior/cargosESalarios/connection/FactoryPostgres.java
+++ b/src/main/java/br/com/proway/senior/cargosESalarios/connection/FactoryPostgres.java
@@ -7,7 +7,7 @@ public final class FactoryPostgres extends FactoryConexao {
 	@Override
 	public Connection criarConexao() {
 		ConnectionPostgres conexao = ConnectionPostgres.getInstance();
-		return conexao.conectar();
+		return conexao.getConnection();
 	}
 
 }


### PR DESCRIPTION
Cada vez que o método "conectar()" é chamado, uma nova conexão é atrelada ao banco de dados. Isso ocorre na função "DriverManager.getConnection(url, usuario, senha);"

Acredito que salvando essa conexão em uma variável static de modo que não seja necessário chamar o "conectar" de fora do próprio singleton.

Ao realizar os testes notamos uma diminuição na quantidade de erros, logo essa mudança foi efetiva até um ponto. 

Algo a verificar seria o método "getConnection()" e se de fato é necessário reinstanciar a conexao dentro dele (a conexao deveria ter sido instanciada quando a factory cria e retorna o objeto ConnectionPostgres)